### PR TITLE
MicroShop Cart Updates

### DIFF
--- a/MicroShop/src/FrontEnd/Web.MvcApp/Controllers/CartController.cs
+++ b/MicroShop/src/FrontEnd/Web.MvcApp/Controllers/CartController.cs
@@ -20,10 +20,10 @@ public sealed class CartController(ICartService cartService) : Controller
         return RedirectToAction(nameof(Index));
     }
 
-    [HttpGet("{cartDetailsId}"]
-    public async Task<IActionResult> Remove([FromQuery] int cartDetailsId)
+    [HttpPost]
+    public async Task<IActionResult> Remove([FromForm] int cartDetailsId)
     {
-        if (!ModelState.IsValid)
+        if (cartDetailsId <= 0)
         {
             TempData["error"] = "Invalid Request";
             return RedirectToAction(nameof(Index));

--- a/MicroShop/src/FrontEnd/Web.MvcApp/Views/Cart/Index.cshtml
+++ b/MicroShop/src/FrontEnd/Web.MvcApp/Views/Cart/Index.cshtml
@@ -61,9 +61,10 @@
                                 <span style="font-size:17px;"> @item.Count</span>
                             </div>
                             <div class="col-2 col-lg-1 p-0 pt-lg-4 text-center">
-                                <a asp-action="Remove" asp-route-cartDetailsId="@item.Id" class="btn btn-sm btn-danger">
+                                <input type="hidden" value="@item.Id" name="CartDetailsId"/>
+                                <button type="submit" asp-action="Remove" class="btn btn-link">
                                     <i class="bi bi-trash-fill"></i>
-                                </a>
+                                </button>
                             </div>
                         </div>
                     }

--- a/MicroShop/src/Services/ShoppingCart/ApiApp/Api/ShoppingCartApiRouteBuilderExtensions.cs
+++ b/MicroShop/src/Services/ShoppingCart/ApiApp/Api/ShoppingCartApiRouteBuilderExtensions.cs
@@ -127,14 +127,14 @@ internal static class ShoppingCartApiRouteBuilderExtensions
     private static RouteGroupBuilder MapDeleteCartById(this RouteGroupBuilder builder)
     {
         builder
-            .MapPost("/{id}", Handler)
+            .MapDelete("/{id}", Handler)
             .RequireAuthorization()
             .WithName("DeleteFromCart")
             .WithOpenApi();
 
         return builder;
 
-        static async Task<Results<NoContent, BadRequest<ResponseDto>>> Handler([FromRoute] int id, HttpContext context, [FromServices] ICartService cartService)
+        static async Task<Results<NoContentWithResponseResult, BadRequest<ResponseDto>>> Handler([FromRoute] int id, HttpContext context, [FromServices] ICartService cartService)
         {
             if (!TryGetUserIdFromHttpContext(context, out string? userId))
             {
@@ -143,7 +143,7 @@ internal static class ShoppingCartApiRouteBuilderExtensions
 
             ResponseDto result = await cartService.RemoveFromCart(userId, id);
             return result.Success
-                ? TypedResults.NoContent()
+                ? NoContentWithResponseResult.Success()
                 : TypedResults.BadRequest(result);
         }
     }


### PR DESCRIPTION
- fixed CartController Remove to function as a button and get cartDetailsId using [FromForm] attribute, previously it was confused with Index
- updated ShoppingCartApiRoujteBuilderExtensions to treat MapDeleteCartById to map using Delete verb and to return a JSON response